### PR TITLE
Fix null termination in stringbuilder and refactor

### DIFF
--- a/src/include/stringbuilder.h
+++ b/src/include/stringbuilder.h
@@ -25,6 +25,16 @@ void sb_destroy(stringbuilder* sb, int free_string);
 stringbuilder* sb_new_with_size(int size);
 
 /**
+ * Resets the stringbuilder to empty
+ */
+void sb_reset(stringbuilder* sb);
+
+/**
+ * Appends the given character to the string builder
+ */
+void sb_append_ch(stringbuilder* sb, const char ch);
+
+/**
  * Appends at most length of the given src string to the string buffer
  */
 void sb_append_strn(stringbuilder* sb, const char* src, int length);
@@ -48,19 +58,5 @@ char* sb_make_cstring(stringbuilder* sb);
  * Returns the stringbuilder as a regular C String
  */
 #define sb_cstring(sb) ((sb)->cstr)
-
-/**
- * Resets the stringbuilder to empty
- */
-#define sb_reset(sb) ((sb)->pos = 0)
-
-#define sb_append_ch(sb, ch)    {                                                       \
-        if ((sb)->pos == (sb)->size)   {                                                \
-            (sb)->reallocs++;                                                           \
-            (sb)->size = (sb)->size + ((sb)->size >> 2) + 1;                            \
-            (sb)->cstr = (char*)realloc((sb)->cstr, (sb)->size );                       \
-        }                                                                               \
-        (sb)->cstr[(sb)->pos++] = ch;                                                   \
-    }                                                                           
                                                             
 #endif // STRINGBUILDER_H

--- a/src/testing/stringbuilder_test.c
+++ b/src/testing/stringbuilder_test.c
@@ -11,6 +11,10 @@ static void _assert_sb_stats(stringbuilder* sb, const char* str, int size, int r
         fprintf(stderr, "SB string (%s) does not match '%s'\n", sb_cstring(sb), str);
         exit(-1);
     }
+
+    if (strlen(str) != strlen(sb_cstring(sb))) {
+        fprintf(stderr, "CSTR size expected to be %d, but is %d\n", strlen(str), strlen(sb_cstring(sb)));
+    }
     
     if (size != sb->size)   {
         fprintf(stderr, "SB Size (%d) does not match required size (%d)\n", sb->size, size);
@@ -26,6 +30,10 @@ static void _assert_sb_stats(stringbuilder* sb, const char* str, int size, int r
 DEFINE_TEST_FUNCTION {  
     char *cstr;
     stringbuilder* sb = sb_new_with_size(1);
+    if (0 != strlen(sb->cstr)) {
+        fprintf(stderr, "CSTR expected to have length 0, has length %d\n", strlen(sb->cstr));
+        exit(-1);
+    }
     
     sb_append_ch(sb, 'H');
     sb_append_ch(sb, 'e');
@@ -41,7 +49,7 @@ DEFINE_TEST_FUNCTION {
     sb_append_ch(sb, 'd');
     sb_append_ch(sb, '!');
     
-    _assert_sb_stats(sb, "Hello, World!", strlen("Hello, World!")+1, 7);
+    _assert_sb_stats(sb, "Hello, World!", 16, 4);
     
     cstr = sb_make_cstring(sb);
     if (strcmp(cstr, "Hello, World!"))  {
@@ -51,20 +59,21 @@ DEFINE_TEST_FUNCTION {
     free(cstr);
         
     sb_reset(sb);
+    _assert_sb_stats(sb, "", 16, 4);
     
     sb_append_ch(sb, 'H');
     sb_append_ch(sb, 'i');
     sb_append_ch(sb, '!');
-    _assert_sb_stats(sb, "Hi!", strlen("Hello, World!")+1, 7);
+    _assert_sb_stats(sb, "Hi!", 16, 4);
     
     sb_append_str(sb, "This is a longer string that I am appending, doncha know");
-    _assert_sb_stats(sb, "Hi!This is a longer string that I am appending, doncha know", 71, 8);
+    _assert_sb_stats(sb, "Hi!This is a longer string that I am appending, doncha know", 64, 5);
     
     sb_append_ch(sb, '?');
-    _assert_sb_stats(sb, "Hi!This is a longer string that I am appending, doncha know?", 71, 8);
+    _assert_sb_stats(sb, "Hi!This is a longer string that I am appending, doncha know?", 64, 5);
     
     sb_append_strf(sb, " And %s %s!", "even", "longer");
-    _assert_sb_stats(sb, "Hi!This is a longer string that I am appending, doncha know? And even longer!", 79, 9);
+    _assert_sb_stats(sb, "Hi!This is a longer string that I am appending, doncha know? And even longer!", 128, 6);
     
     sb_destroy(sb, 1);
     return 0;


### PR DESCRIPTION
I'm not sure how you'll feel about all of these changes, but I feel they make the code simpler and safer.  Let me know if you want to discuss anything.
# COMMIT COMMENTS BELOW

Fix an issue in stringbuilder whereby it was not null terminating
strings correctly.  In applying this fix, a number of vaguely related
changes are made.

stringbuilder
- Fill string buffer with null on creation and resize to ensure any
  characters not written to the string are null, and the buffer is
  therefore always null terminated.
- Make sb_reset a function, not a macro
- Add sb_resize function as reusuable and consistent means of resizing
  buffer
- Add sb_double_size as a convenience function to double the buffer size
- Make sb_append_ch a function, not a macro
- Change resize strategy in sb_append_strn to keep doubling the new
  buffer size until the string to be appended will fit

stringbuilder_test
- Add check of cstring's length to _assert_sb_stats
- Modify tests to match new code
